### PR TITLE
Fixed alarm_control_panel error during init

### DIFF
--- a/custom_components/cleveroom/fan.py
+++ b/custom_components/cleveroom/fan.py
@@ -113,19 +113,23 @@ class CleveroomFan(KLWEntity,FanEntity):
         detail = device["detail"]
         # 读取设备状态
         self._is_on = detail.get("on", False)
-        #speed 1-3 ->0~2
-        if detail.get("speed") is not None:
-            v = detail.get("speed")
-            if 1 <= v <= 3:
-                self._speed = v
+        self._speed = detail.get("speed", 0)
 
     @property
     def is_on(self) -> bool:
         return self._is_on
 
     @property
-    def percentage(self) -> str | None:
-        speeds = [0,33, 66, 100]
+    def percentage(self) -> Optional[int]:
+        """Return the current speed percentage."""
+        speeds = [0, 33, 66, 100]
+        if not self._is_on:
+            return 0
+        # Add safety check to ensure index is within valid range
+        if self._speed is None or self._speed < 0 or self._speed >= len(speeds):
+            _LOGGER.warning(
+                f"Fan {self._oid} has an invalid speed value {self._speed}, using default value")
+            return 0
         return speeds[self._speed]
 
     @property


### PR DESCRIPTION
Fix Issue #1  #2

## Main modification instructions

1. Removed the import of AlarmControlPanelState and replaced with the standard state constant using Home Assistant:

```
STATE_ALARM_ARMED_AWAY
STATE_ALARM_DISARMED
STATE_ALARM_TRIGGERED
```

2. Modified the implementation of the class, replaced `_attr_alarm_state` with `_state`, and updated the relevant attributes and methods:

- Added the state property method to replace the original alarm_state
- Modified the code for all state settings to use new state constants

3. Keep the original functional logic unchanged, and only adjusts the implementation method of state management

This modification should solve the problem of ImportError: cannot import name 'AlarmControlPanelState' while keeping the component's functionality complete.

Additionally, this PR also fixes the index out of range error in fan component.

## Fix for fan component

Fixed an IndexError issue in the percentage property where speeds[self._speed] would throw an exception when self._speed is out of valid range.

This change prevents component crashes when speed values become invalid while maintaining the component's normal functionality.